### PR TITLE
Enable Sentry source maps

### DIFF
--- a/pigeon-backend.js
+++ b/pigeon-backend.js
@@ -210,9 +210,10 @@ class PigeonBackend extends BaseBackend {
         const frames = stack.map(frame => {
             const parsedFrame = {
                 colno: frame.columnNumber,
-                filename: frame.fileName || '',
+                filename: frame.fileName ? 'app:///' + frame.fileName : null,
                 function: this.getFunction(frame),
                 lineno: frame.lineNumber,
+                platform: 'javascript'
             };
             return parsedFrame;
         });


### PR DESCRIPTION
Thanks for publishing this client. We are using it with our Workers but were missing on not having source code reference directly in the reported event.

To get source in Sentry first we had to adjust the output to `worker.js`, matching how CloudFlare would run the code, by configuring webpack to output `worker.js` and `worker.js.map` source map to `dist/`. Our sample webpack config is here: https://gist.github.com/grakic/87a055d3a8eff8cdf179df5d3f277d71

In our CI pipeline we use SentryCliPlugin webpack plugin to upload those two files as Sentry release artifacts. Uploaded artifacts appear as `~/worker.js` and `~/worker.js.map`. We also use `DefinePlugin` webpack plugin to set the same release in the Pigeon init in our code that is in `src/index.js`:
```  ...
  Pigeon.init({
    dsn: SENTRY_DSN,
    event: event,
    release: RELEASE,
  });
```

Adding `app:///` prefix will tell Sentry to resolve this source and source map locally, and the only thing that appears as missing is this `platform: javascript`.

Having those two we can have source code reported in Sentry:

![sentry-example](https://user-images.githubusercontent.com/712022/70265888-a0996a80-179b-11ea-9b8f-6823d2bb7038.png)
